### PR TITLE
Implement **depot.object scheme

### DIFF
--- a/tests/test_depot.py
+++ b/tests/test_depot.py
@@ -3,8 +3,8 @@ import datetime
 
 import pytest
 
-from hworker.depot import *
-from hworker.depot.objects import *
+from hworker.depot import store, delete, search
+from hworker.depot.objects import Homework, Criteria
 
 
 class TestDepotFunctions:
@@ -37,6 +37,20 @@ def homeworks():
     delete(Homework)
 
 
+class TestComparison:
+    def test_equals(self, homeworks):
+        hw, hw2 = list(search(Homework))[:2]
+        assert hw == hw
+        assert hw != hw2
+        assert hw @ hw
+
+    def test_almost_equal(self, homeworks):
+        hw = list(search(Homework))[0]
+        newhw = Homework(**hw, content={"No": b"Way"}, is_broken=False)
+        assert hw != newhw
+        assert hw @ newhw
+
+
 class TestDepotFunctionsWithCriteria:
     def test_get_all_homework(self, homeworks):
         assert len(list(search(Homework))) == 9
@@ -54,8 +68,7 @@ class TestDepotFunctionsWithCriteria:
                         Criteria("timestamp", "<=", datetime.datetime(2023, 6, 30).timestamp()),
                     )
                 )
-            )
-            == 6
+            ) == 6
         )
 
     def test_del_all_homework_from_user(self, homeworks):


### PR DESCRIPTION
Реализовал `{**StoreObject()}` — получение словаря полей объекта. Предположительно нужно для создания объекта дочернего класса на основании объекта родительского класса, например:
```
 def createSolution(hw: Homework) -> Solution:
    sol = Solution(**hw)
    … fill sol.content from hw.content …
    … fill sol.checks
    return sol
```
Ввёл понятие «публичные поля» (`_public_fields`) — поля, которые включаются в этот словарь. 
При этом работает также `StoreObject().items()`, `StoreObject().keys()` и `StoreObject().values()`. Реализовал через `.items()` сравнение почти похожих объектов `A @ B` (читается как `A` подобно `B`).

Сравнение объектов при этом должно проверять _все_ data-поля, так что я ещё сделал итератор по объекту, `[*StoreObject()]`, который выдаёт все пары `поле_данных: значение` . Соответственно сравнение `==` реализовано через итератор.

Сделал пару простых тестов.