### PR TITLE
Config new generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ test.db
 data.db
 hworker/_version.py
 hworker.toml
-test_hworker.toml
 final_hworker.toml
+*_final.toml
 .history
 
 Pipfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test.db
 data.db
 hworker/_version.py
 hworker.toml
+test_hworker.toml
 final_hworker.toml
 .history
 

--- a/hworker/config/default_hworker.toml
+++ b/hworker/config/default_hworker.toml
@@ -17,11 +17,11 @@ directory = "/tmp/hworker_git"
 # user_ID = "repo"
 
 [imap]
-host = "host"  # example, fill it
-port = "993"
-folder = "folder"  # example, fill it
-username = "username"  # example, fill it
-password = "password"  # example, fill it
+# host = "host"
+port = 993
+# folder = "folder"
+# username = "username"
+# password = "password"
 letter_limit = -1
 
 [imap.users]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+""""""
+import pytest
+import hworker.config
+
+
+@pytest.fixture(scope="session", autouse=True)
+def global_user_config(tmp_path_factory):
+    config = tmp_path_factory.getbasetemp() / "testconfig.toml"
+    hworker.config.create_config(config, {})
+    hworker.config.process_configs(str(config))

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -4,7 +4,6 @@ from hworker.check.runtime import python_runner, check_wo_store
 from hworker.check.validate import validate_wo_store
 from hworker.depot.objects import Check, Solution, CheckResult, CheckCategoryEnum, VerdictEnum
 
-import os
 import time
 from datetime import date
 
@@ -12,19 +11,13 @@ import pytest
 
 
 @pytest.fixture()
-def tmp_prog():
+def tmp_prog(tmp_path_factory):
     """"""
-    prog_path = os.path.join(os.path.join(os.path.abspath(os.sep), "tmp", "prog.py"))
-    test_path = os.path.join(os.path.join(os.path.abspath(os.sep), "tmp", "test.in"))
-    with open(prog_path, "wb") as prog:
-        prog.write(b"a, b = eval(input())\n" b"print(max(a, b))")
-    with open(test_path, "wb") as test:
-        test.write(b"123, 345")
-
-    yield prog_path, test_path
-
-    os.remove(prog_path)
-    os.remove(test_path)
+    prog_path = tmp_path_factory.getbasetemp() / "prog.py"
+    test_path = tmp_path_factory.getbasetemp() / "test.in"
+    prog_path.write_bytes(b"a, b = eval(input())\nprint(max(a, b))")
+    test_path.write_bytes(b"123, 345")
+    return prog_path, test_path
 
 
 class TestCheckRuntime:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,21 +21,20 @@ from hworker.config import (
 )
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def make_user_config(request):
     create_config(_user_config_name, request.param)
     yield
     os.remove(_user_config_name)
+    get_final_config.cache_clear()
 
 
-# TODO: cache_clear doesn't work in teardown (why?)
 class TestConfig:
     """"""
 
     @pytest.mark.parametrize("make_user_config", [{"imap": {"host": "host", "folder": "folder"}}], indirect=True)
     def test_imap_info(self, make_user_config):
         assert get_imap_info() == {"letter_limit": -1, "port": 993, "users": {}}
-        get_final_config.cache_clear()
 
     def test_get_names(self):
         assert (get_prog_name(), get_urls_name(), get_checks_suffix(), get_checks_dir()) == (
@@ -49,12 +48,10 @@ class TestConfig:
     @pytest.mark.parametrize("make_user_config", [{"imap": {"users": {"user_ID": "mail address"}}}], indirect=True)
     def test_mail_users(self, make_user_config):
         assert (uid_to_email("user_ID"), email_to_uid("mail address")) == ("mail address", "user_ID")
-        get_final_config.cache_clear()
 
     @pytest.mark.parametrize("make_user_config", [{"git": {"users": {"user_ID": "repo"}}}], indirect=True)
     def test_git_users(self, make_user_config):
         assert (uid_to_repo("user_ID"), repo_to_uid("repo")) == ("repo", "user_ID")
-        get_final_config.cache_clear()
 
     @pytest.mark.parametrize(
         "make_user_config",
@@ -70,4 +67,3 @@ class TestConfig:
             "soft_deadline": datetime(2024, 1, 7, 0, 0),
             "soft_deadline_delta": "open_date+6d",
         }
-        get_final_config.cache_clear()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,38 +1,73 @@
 """"""
 
 import os
+import pytest
+from datetime import datetime
 
-from hworker.config import get_git_directory, get_repos, get_git_uids, repo_to_uid, uid_to_repo, \
-    _default_config_name, _user_config_name, _final_config_name, get_final_config, deliverid_to_taskid, \
-    taskid_to_deliverid, uid_to_email, email_to_uid, get_imap_info, get_checks_suffix, get_checks_dir, get_prog_name, \
-    get_urls_name
+from hworker.config import (
+    create_config,
+    repo_to_uid,
+    uid_to_repo,
+    _user_config_name,
+    uid_to_email,
+    email_to_uid,
+    get_imap_info,
+    get_checks_suffix,
+    get_checks_dir,
+    get_prog_name,
+    get_urls_name,
+    get_task_info,
+    get_final_config,
+)
 
-def test_config():
-    """"""
-    # TODO: check all fields, add tests configs
-    # test_config_name, test_final_config_name = map(lambda s: "test_" + s, (_user_config_name, _final_config_name))
-    get_final_config(
-        default_config=_default_config_name,
-    )
-    # user_config=test_config_name,
-    # final_config=test_final_config_name)
-    assert get_git_directory() == "/tmp/hworker_git"
-    assert get_imap_info() == {"letter_limit": -1, "port": "993", "users": {}}
-    assert get_checks_suffix() == "in/out"
-    assert get_checks_dir() == "checks"
-    assert get_prog_name() == "prog.py"
-    assert get_urls_name() == "remotes"
-    assert uid_to_email("user_ID") == "mail address"
-    assert email_to_uid("mail address") == "user_ID"
-    assert get_repos() == [
-        "repo",
-    ]
-    assert get_git_uids() == [
-        "user_ID",
-    ]
-    assert uid_to_repo("user_ID") == "repo"
-    assert repo_to_uid("repo") == "user_ID"
-    assert taskid_to_deliverid("task_ID") == "20240101/01"
-    assert deliverid_to_taskid("20240101/01") == "task_ID"
+
+@pytest.fixture
+def make_user_config(request):
+    create_config(_user_config_name, request.param)
+    yield
     os.remove(_user_config_name)
-    os.remove(_final_config_name)
+
+
+# TODO: cache_clear doesn't work in teardown (why?)
+class TestConfig:
+    """"""
+
+    @pytest.mark.parametrize("make_user_config", [{"imap": {"host": "host", "folder": "folder"}}], indirect=True)
+    def test_imap_info(self, make_user_config):
+        assert get_imap_info() == {"letter_limit": -1, "port": 993, "users": {}}
+        get_final_config.cache_clear()
+
+    def test_get_names(self):
+        assert (get_prog_name(), get_urls_name(), get_checks_suffix(), get_checks_dir()) == (
+            "prog.py",
+            "remotes",
+            "in/out",
+            "checks",
+        )
+        get_final_config.cache_clear()
+
+    @pytest.mark.parametrize("make_user_config", [{"imap": {"users": {"user_ID": "mail address"}}}], indirect=True)
+    def test_mail_users(self, make_user_config):
+        assert (uid_to_email("user_ID"), email_to_uid("mail address")) == ("mail address", "user_ID")
+        get_final_config.cache_clear()
+
+    @pytest.mark.parametrize("make_user_config", [{"git": {"users": {"user_ID": "repo"}}}], indirect=True)
+    def test_git_users(self, make_user_config):
+        assert (uid_to_repo("user_ID"), repo_to_uid("repo")) == ("repo", "user_ID")
+        get_final_config.cache_clear()
+
+    @pytest.mark.parametrize(
+        "make_user_config",
+        [{"tasks": {"task_ID": {"deliver_ID": "20240101/01", "open_date": datetime(year=2024, month=1, day=1)}}}],
+        indirect=True,
+    )
+    def test_task_info(self, make_user_config):
+        assert get_task_info("task_ID") == {
+            "deliver_ID": "20240101/01",
+            "hard_deadline": datetime(2024, 1, 14, 0, 0),
+            "hard_deadline_delta": "open_date+13d",
+            "open_date": datetime(2024, 1, 1, 0, 0),
+            "soft_deadline": datetime(2024, 1, 7, 0, 0),
+            "soft_deadline_delta": "open_date+6d",
+        }
+        get_final_config.cache_clear()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,14 +1,13 @@
 """"""
 
-import os
 import pytest
 from datetime import datetime
 
 from hworker.config import (
     create_config,
+    process_configs,
     repo_to_uid,
     uid_to_repo,
-    _user_config_name,
     uid_to_email,
     email_to_uid,
     get_imap_info,
@@ -17,24 +16,22 @@ from hworker.config import (
     get_prog_name,
     get_urls_name,
     get_task_info,
-    get_final_config,
 )
 
 
 @pytest.fixture(scope="function")
-def make_user_config(request):
-    create_config(_user_config_name, request.param)
-    yield
-    os.remove(_user_config_name)
-    get_final_config.cache_clear()
+def user_config(request, tmp_path):
+    config = tmp_path / "testconfig.toml"
+    create_config(config, request.param)
+    process_configs(str(config))
 
 
 class TestConfig:
     """"""
 
-    @pytest.mark.parametrize("make_user_config", [{"imap": {"host": "host", "folder": "folder"}}], indirect=True)
-    def test_imap_info(self, make_user_config):
-        assert get_imap_info() == {"letter_limit": -1, "port": 993, "users": {}}
+    @pytest.mark.parametrize("user_config", [{"imap": {"host": "host", "folder": "folder"}}], indirect=True)
+    def test_imap_info(self, user_config):
+        assert get_imap_info() == {"letter_limit": -1, "port": 993, "users": {}, "host": "host", "folder": "folder"}
 
     def test_get_names(self):
         assert (get_prog_name(), get_urls_name(), get_checks_suffix(), get_checks_dir()) == (
@@ -43,22 +40,21 @@ class TestConfig:
             "in/out",
             "checks",
         )
-        get_final_config.cache_clear()
 
-    @pytest.mark.parametrize("make_user_config", [{"imap": {"users": {"user_ID": "mail address"}}}], indirect=True)
-    def test_mail_users(self, make_user_config):
+    @pytest.mark.parametrize("user_config", [{"imap": {"users": {"user_ID": "mail address"}}}], indirect=True)
+    def test_mail_users(self, user_config):
         assert (uid_to_email("user_ID"), email_to_uid("mail address")) == ("mail address", "user_ID")
 
-    @pytest.mark.parametrize("make_user_config", [{"git": {"users": {"user_ID": "repo"}}}], indirect=True)
-    def test_git_users(self, make_user_config):
+    @pytest.mark.parametrize("user_config", [{"git": {"users": {"user_ID": "repo"}}}], indirect=True)
+    def test_git_users(self, user_config):
         assert (uid_to_repo("user_ID"), repo_to_uid("repo")) == ("repo", "user_ID")
 
     @pytest.mark.parametrize(
-        "make_user_config",
+        "user_config",
         [{"tasks": {"task_ID": {"deliver_ID": "20240101/01", "open_date": datetime(year=2024, month=1, day=1)}}}],
         indirect=True,
     )
-    def test_task_info(self, make_user_config):
+    def test_task_info(self, user_config):
         assert get_task_info("task_ID") == {
             "deliver_ID": "20240101/01",
             "hard_deadline": datetime(2024, 1, 14, 0, 0),

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -1,7 +1,5 @@
 """Tests for deliver.git"""
 
-from hworker.deliver.git import get_homework_content
-
 import os
 import shutil
 
@@ -37,6 +35,8 @@ class TestDeliverGit:
 
     def test_get_homework_content(self, example_git_repo):
         """"""
+        from hworker.deliver.git import get_homework_content
+
         assert get_homework_content(example_git_repo) == {
             "test_repo": {
                 "prog.py": b"a, b = eval(input())\n" b"print(max(a, b))",


### PR DESCRIPTION
Редизайн config:

- Можно указывать любое количество конфиг-файлов (в довесок к дефолтным из модуля)
- Результат (словарь с конфигом и список файлов) хранится в глобальной переменной `config.profile`
  - `profile` — это список, ссылка на который не меняется в течение работы системы (но сам он может поменяться) 
- Сохранил логику «создать финальный конфиг при первом обращении»
 - Имя финального конфига генерится из имени первого пользовательского конфига
 - Добавил в тесты глобальную фикстуру, которая уносит конфиг во временный каталог