### PR TITLE
Новая логика m ultoback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv/
 logs/
 t_*.py
 
+tags
 test.db
 data.db
 hworker/_version.py

--- a/hworker/deliver/__init__.py
+++ b/hworker/deliver/__init__.py
@@ -1,4 +1,4 @@
-from ..config import get_deliver_modules as _backends
+from .. import config
 from .. import multiback
 
 
@@ -6,4 +6,4 @@ def download_all() -> None:
     """Download all homeworks from all backends"""
 
 
-multiback.init_backends(backends=_backends, methods=["download_all"])
+multiback.init_backends(backends=config.get_deliver_modules)

--- a/hworker/deliver/__init__.py
+++ b/hworker/deliver/__init__.py
@@ -1,4 +1,9 @@
-from ..config import get_deliver_modules
-from ..multiback import init_backends
+from ..config import get_deliver_modules as _backends
+from .. import multiback
 
-init_backends(backends=get_deliver_modules(), methods=["download_all"])
+
+def download_all() -> None:
+    """Download all homeworks from all backends"""
+
+
+multiback.init_backends(backends=_backends, methods=["download_all"])

--- a/proposals/multiback_client/__init__.py
+++ b/proposals/multiback_client/__init__.py
@@ -2,7 +2,12 @@
 """
 """
 
-from hworker.multiback import init_backends
-from .A import method  # NoQA F401
+from hworker import multiback
 
-init_backends(["A", "B"], ["method"], uniform=True)
+
+def method(par: str) -> int:
+    """Sample method"""
+    return -1
+
+
+multiback.init_backends(["A", "B"], uniform=True)

--- a/tests/test_multiback.py
+++ b/tests/test_multiback.py
@@ -7,34 +7,47 @@ import sys
 import os
 import importlib
 
+DOCSTRING = "Sample method"
+PARAMS = [[_ := list("ABC"[: i + 1]), _ if k else "_methods"] for i in range(3) for k in range(2)]
+PARNAMES = ["-".join(("".join(p[0]), "".join(p[1]))) for p in PARAMS]
 
-@pytest.fixture(params=[["A"], ["A", "B"], ["A", "B", "C"]])
-def tmp_libdir(tmp_path, request):
+
+@pytest.fixture(params=PARAMS, ids=PARNAMES)
+def genmodule(tmp_path, request):
     """Create a test package with one method in each backand"""
     modpath = tmp_path / "multiback_client"
     modpath.mkdir()
     (modpath / "__init__.py").write_text(
         f"""
 from hworker.multiback import init_backends
-init_backends({request.param}, ["method"], uniform=True)
+def _methods():
+    return {request.param[0]}
+
+def method(arg: int) -> int:
+    "{DOCSTRING}"
+    return arg
+
+init_backends({request.param[0]}, ["method"], uniform=True)
 """
     )
-    for n, back in enumerate(request.param):
+    for n, back in enumerate(request.param[0]):
         (modpath / f"{back}.py").write_text(
             f"""
 def method(i):
     return {n} + i
 """
         )
-    return tmp_path, request.param
+    yield tmp_path, request.param[0]
 
 
-def test_full(tmp_libdir):
-    """Import test package, call aggregated mtthods"""
-    libdir, backends = tmp_libdir
-    sys.path[0] = os.path.join(libdir.absolute())
-    import multiback_client
+class TestMultiback:
+    def test_full(self, genmodule):
+        """Import test package, call aggregated mtthods"""
+        libdir, backends = genmodule
+        sys.path[0] = os.path.join(libdir.absolute())
+        import multiback_client
 
-    importlib.reload(multiback_client)  # To prevent caching
-    res = multiback_client.method(0)
-    assert res == (len(backends) * (len(backends) - 1)) // 2
+        importlib.reload(multiback_client)  # To prevent caching
+        assert multiback_client.method.__doc__ == DOCSTRING
+        res = multiback_client.method(0)
+        assert res == (len(backends) * (len(backends) - 1)) // 2

--- a/tests/test_multiback.py
+++ b/tests/test_multiback.py
@@ -27,7 +27,7 @@ def method(arg: int) -> int:
     "{DOCSTRING}"
     return arg
 
-init_backends({request.param[0]}, ["method"], uniform=True)
+init_backends({request.param[0]}, uniform=True)
 """
     )
     for n, back in enumerate(request.param[0]):


### PR DESCRIPTION
Обнаружил крайне неприятную фичу `.multiback`: список бекендов при _уже при импорте_ брался из конфига _до выбора_ конфиг-файлов.

Фикс отодвигает вызов метода из конфига на момент после после настройки. Теперь вместо списка бекендов можно передать функцию, которая вернёт список бекендов, _когда её вызовут_.

Поскольку теперь при импорте мы можем не знать имена актуальных бекендов, убрал костыль с импортированием метаинформации о методе из _первого_ из них. Теперь все методы верхнего уровня в модуле с бекендами (не начинающиесчя на "`_`") считаются прототипами соответствующих врапперов, метаинформация берётся из них.

Соответственно, нет необходимости передавать в `init_backend()` список методов — это просто все методы верхнего уровня, чьи имена не начинаются на "`_`". Убрал этот параметр.